### PR TITLE
Use more comprehensive hostname regex pattern Fix

### DIFF
--- a/domainre.go
+++ b/domainre.go
@@ -3,7 +3,7 @@ package isdomain
 import "regexp"
 
 // DomainRegexpStr is a regular expression string to validate domains.
-const DomainRegexpStr = "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"
+const DomainRegexpStr = "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$"
 
 var domainRegexp *regexp.Regexp
 


### PR DESCRIPTION
I fix [this](https://github.com/jbenet/go-is-domain/pull/3) pull request. 
I hope you will accept it. I use the Cyrillic domain.

Sourced from http://stackoverflow.com/a/3824105

The current regex has issues with DNS names with multiple -s in them,
which happens with IDNs with Punycode. Also doesn't follow the RfC limit
of 63 octets per label.

User gfdfgh reported this on #ipfs

Fix for #7 and https://github.com/ipfs/go-ipfs/issues/4153