### PR TITLE
Use more comprehensive hostname regex pattern Fix

### DIFF
--- a/domainre.go
+++ b/domainre.go
@@ -3,7 +3,7 @@ package isdomain
 import "regexp"
 
 // DomainRegexpStr is a regular expression string to validate domains.
-const DomainRegexpStr = "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"
+const DomainRegexpStr = "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$"
 
 var domainRegexp *regexp.Regexp
 

--- a/is_domain.go
+++ b/is_domain.go
@@ -34,10 +34,19 @@ func IsDomain(s string) bool {
 		s = s[:len(s)-1]
 	}
 	split := strings.Split(s, ".")
+
+	// Need a TLD and a domain.
+	if len(split) < 2 {
+		return false
+	}
+
+	// Check the TLD
 	tld := split[len(split)-1]
 	if !IsTLD(tld) {
 		return false
 	}
+
+	// Check the domain.
 	s = strings.ToLower(s)
 	return domainRegexp.MatchString(s)
 }

--- a/is_domain_test.go
+++ b/is_domain_test.go
@@ -10,6 +10,10 @@ func TestBasic(t *testing.T) {
 		"com":              false, // yeah yeah...
 		".":                false, // yeah yeah...
 		"..":               false,
+		".com":             false,
+		".com.":            false,
+		"com.":             false,
+		"com..":            false,
 		".foo.com.":        false,
 		".foo.com":         false,
 		"fo o.com":         false,


### PR DESCRIPTION
I fix [this](https://github.com/jbenet/go-is-domain/pull/3) pull request. I hope you will accept it. I use the Cyrillic domain.

Sourced from http://stackoverflow.com/a/3824105

The current regex has issues with DNS names with multiple -s in them, which happens with IDNs with Punycode. Also doesn't follow the RfC limit of 63 octets per label.

User gfdfgh reported this on #ipfs