### PR TITLE
feat: add .crypto and .zil from UnstoppableDomains

### DIFF
--- a/tlds_custom.go
+++ b/tlds_custom.go
@@ -3,7 +3,9 @@ package isdomain
 // ExtendedTLDs is a set of additional "TLDs", allowing decentralized name
 // systems, like TOR and Namecoin.
 var ExtendedTLDs = map[string]bool{
-	"BIT":   true,
-	"ONION": true,
-	"ETH":   true,
+	"BIT":    true, // namecoin.org
+	"ONION":  true, // torproject.org
+	"ETH":    true, // ens.domains
+	"CRYPTO": true, // unstoppabledomains.com
+	"ZIL":    true, // unstoppabledomains.com
 }


### PR DESCRIPTION
This PR adds `.crypto` and `.zil` TLDs from https://unstoppabledomains.com

cc @Stebalien  @autonome as we need this for DNSLink-based support similar to ENS ( https://github.com/ipfs/go-ipfs/pull/6448), as suggested in https://github.com/ipfs-shipyard/ipfs-companion/pull/875#issuecomment-626905241